### PR TITLE
Fix plugin hub build failure and correct xp values (#28, #27)

### DIFF
--- a/src/main/java/com/bankxpvalue/BankXpValueItemOverlay.java
+++ b/src/main/java/com/bankxpvalue/BankXpValueItemOverlay.java
@@ -3,7 +3,7 @@ package com.bankxpvalue;
 import java.awt.*;
 
 import net.runelite.api.*;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.ui.SkillColor;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPriority;
@@ -51,7 +51,7 @@ public class BankXpValueItemOverlay extends Overlay {
         final MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
         final int widgetId = menuEntry.getParam1();
 
-        if (widgetId != WidgetInfo.BANK_ITEM_CONTAINER.getId()){
+        if (widgetId != InterfaceID.Bankmain.ITEMS){
             return null;
         }
 

--- a/src/main/java/com/bankxpvalue/BankXpValueOverlay.java
+++ b/src/main/java/com/bankxpvalue/BankXpValueOverlay.java
@@ -12,7 +12,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.*;
 import net.runelite.client.ui.SkillColor;
 import net.runelite.client.util.ColorUtil;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.components.*;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
@@ -69,7 +69,7 @@ public class BankXpValueOverlay extends OverlayPanel {
             resetPositionToCenter();
         }
 
-        bank = client.getWidget(WidgetInfo.BANK_CONTAINER);
+        bank = client.getWidget(InterfaceID.Bankmain.UNIVERSE);
 
         panelComponent.getChildren().clear();
 

--- a/src/main/java/com/bankxpvalue/BankXpValuePlugin.java
+++ b/src/main/java/com/bankxpvalue/BankXpValuePlugin.java
@@ -2,9 +2,8 @@ package com.bankxpvalue;
 
 import net.runelite.api.*;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.plugins.Plugin;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.events.ConfigChanged;
@@ -75,7 +74,7 @@ public class BankXpValuePlugin extends Plugin {
     @Subscribe
     public void onMenuEntryAdded(MenuEntryAdded event){
         if (event.getType() != MenuAction.CC_OP.getId() || !event.getOption().equals("Show menu")
-                || (event.getActionParam1() >> 16) != WidgetID.BANK_GROUP_ID){
+                || (event.getActionParam1() >> 16) != InterfaceID.BANKMAIN){
             return;
         }
 
@@ -100,7 +99,7 @@ public class BankXpValuePlugin extends Plugin {
     }
 
     public void onClick(MenuEntry entry){
-        bank = client.getWidget(WidgetInfo.BANK_CONTAINER);
+        bank = client.getWidget(InterfaceID.Bankmain.UNIVERSE);
         if (bank == null){
             overlayManager.remove(overlay);
             pluginToggled = false;

--- a/src/main/java/com/bankxpvalue/BankXpValueTutorialOverlay.java
+++ b/src/main/java/com/bankxpvalue/BankXpValueTutorialOverlay.java
@@ -6,7 +6,7 @@ import javax.inject.Singleton;
 
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
@@ -38,13 +38,13 @@ public class BankXpValueTutorialOverlay extends OverlayPanel {
             return null;
         }
 
-        bank = client.getWidget(WidgetInfo.BANK_CONTAINER);
+        bank = client.getWidget(InterfaceID.Bankmain.UNIVERSE);
 
         if (bank == null || bank.isHidden()){
             return null;
         }
 
-        Widget button = client.getWidget(WidgetInfo.BANK_SETTINGS_BUTTON);
+        Widget button = client.getWidget(InterfaceID.Bankmain.MENU_BUTTON);
         if (button == null || button.isSelfHidden() || button.getDynamicChildren()[0].getSpriteId() != 195){
             return null;
         }

--- a/src/main/resources/item_xp_data.json
+++ b/src/main/resources/item_xp_data.json
@@ -222,7 +222,17 @@
     },
     {
       "id": 28899,
-      "xp": 21,
+      "xp": 73.5,
+      "skill": "prayer"
+    },
+    {
+      "id": 29378,
+      "xp": 270,
+      "skill": "prayer"
+    },
+    {
+      "id": 29381,
+      "xp": 6,
       "skill": "prayer"
     },
     {
@@ -1171,6 +1181,11 @@
       "skill": "farming"
     },
     {
+      "id": 5370,
+      "xp": 481.3,
+      "skill": "farming"
+    },
+    {
       "id": 5371,
       "xp": 1481.5,
       "skill": "farming"
@@ -1186,7 +1201,7 @@
       "skill": "farming"
     },
     {
-      "id": 5734,
+      "id": 5374,
       "xp": 13913.8,
       "skill": "farming"
     },


### PR DESCRIPTION
Unblocks the plugin hub submission that has been stuck since Aug 2024 ([plugin-hub#6483](https://github.com/runelite/plugin-hub/pull/6483)), and corrects the xp values people have reported since.

Deliberately scoped to only what can be verified without a running client: the API swap needed for CI, and item data. No behaviour changes, no refactors, no new dependencies, no build changes. Ships as **1.2.3** — the version already bumped on master and never released.

## Why the hub build failed

The CI logs expired long ago, so I reproduced it against the packager instead. The plugin hub treats *terminally deprecated* RuneLite APIs as a fatal build error, and its `disallowed-apis.txt` bans exactly what this plugin used:

```
# Use ComponentID or InterfaceID instead of WidgetInfo or WidgetID
/^Lnet/runelite/api/widgets/WidgetInfo;/
/^Lnet/runelite/api/widgets/WidgetID/
```

Both were used across all four source files. Mapped to `net.runelite.api.gameval.InterfaceID` by verified constant value:

| Old | New | Value |
|---|---|---|
| `WidgetID.BANK_GROUP_ID` | `InterfaceID.BANKMAIN` | 12 |
| `WidgetInfo.BANK_CONTAINER` | `InterfaceID.Bankmain.UNIVERSE` | 786433 |
| `WidgetInfo.BANK_ITEM_CONTAINER` | `InterfaceID.Bankmain.ITEMS` | 786444 |
| `WidgetInfo.BANK_SETTINGS_BUTTON` | `InterfaceID.Bankmain.MENU_BUTTON` | 786538 |

Every changed Java line is a one-for-one swap resolving to the same constant, so there is no behaviour to re-test in game.

## Item xp values

**Magic saplings (#28) were a transposed digit.** The entry read `5734` instead of `5374`, which is `Black spear(p+)`. Magic saplings showed no xp, *and* a poisoned black spear counted as 13,913.8 farming xp.

- fix magic sapling id `5734` -> `5374` (#28)
- add oak sapling (`5370`), missing entirely (#28)
- add sun-kissed bones (`29378`) and blessed bone shards (`29381`) (#27)
- correct wyrmling bones `21` -> `73.5` (#27) — already present, but filed at the *burial* rate while every other bone in the file uses the gilded-altar rate, so they read ~3.5x low

Blessed wine jugs are deliberately **not** added — they modify the per-shard rate rather than carrying xp themselves, so counting them would double-count the shards.

> **Worth a second opinion:** blessed bone shards are entered at **6 xp** (sunfire wine) and sun-kissed bones at **270**, following the file's existing best-rate convention — every bone already assumes a gilded altar with two burners. If you'd rather assume plain blessed wine, those become 5 and 225.

## Already fixed, never shipped

v1.2.2 is what's live in the hub, so monkfish at 150 cooking xp (#21) and raw bass (#20) were fixed here but never released. They ship with this.

## Verification

- `gradlew build` green
- Bytecode scanned against every entry in `disallowed-apis.txt`: no hits
- Item ids resolved against RuneLite's own `ItemID` constants, xp values checked against the wiki
- Confirmed no Java line changes behaviour — the whole diff is import and constant substitution

## Not included

#26 (level-ups on a maxed skill) and #14 (overlay recentring on restart) are real bugs with understood causes, but both are behaviour changes that can't be confirmed without playing the game, so they're intentionally left out rather than shipped untested. #12, #3, #15 and #5 are untouched.