### PR TITLE
Declare build type in runelite-plugin.properties

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -4,3 +4,5 @@ support=https://github.com/dseeler/bank-xp-value
 description=All-in-one banked xp viewer + item xp tooltips
 tags=bank, xp, calc, item, skill, overlay, tooltip
 plugins=com.bankxpvalue.BankXpValuePlugin
+version=1.2.3
+build=standard


### PR DESCRIPTION
Follow-up to #31. The plugin hub build for [plugin-hub#14553](https://github.com/runelite/plugin-hub/pull/14553) got further than it has in two years — the compile and the API scan both **passed**, confirming the `WidgetInfo`/`WidgetID` fix worked:

```
> Task :compileJava
> Task :runelitePluginHubPackage
> Task :runelitePluginHubManifest
BUILD SUCCESSFUL in 14s
```

It then failed on a separate, newer requirement:

```
bank-xp-value: "build" must be set
You must add a build=standard or build=gradle entry.
```

This requirement postdates 1.2.2, which is why the plugin shipped fine without it before.

## The change

```properties
version=1.2.3
build=standard
```

**`build=standard`** — the hub recommends it unless you have custom dependencies. This plugin's only dependencies are the RuneLite client and lombok, both already provided by the hub's standard build. Verified the plugin compiles under those exact terms (lombok 1.18.30, `--release 11`), which is what the hub will use since standard mode replaces `build.gradle`.

**`version=1.2.3`** is required *because* of `build=standard`, not independently. The packager resolves the version as:

1. the `version` key in `runelite-plugin.properties`
2. else, the gradle version — **but only when `build=gradle`**
3. else, the first 8 characters of the commit hash

Under `build=standard` step 2 is skipped, so without an explicit key the hub would have displayed the version as `011286c8` instead of `1.2.3`.

## Note

The packager also warns `unused props in runelite-plugin.properties: [support]` — `support` is no longer a recognised key. It's only a warning and I've left it alone rather than widen this change; easy to drop later if you want the log clean.